### PR TITLE
Traduction de `non-node.md`

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -10,7 +10,7 @@
 - [Gestion des entêtes](head.md)
 - [Mise en cache](caching.md)
 - [Envoi par flux](streaming.md)
-- [Utilisation dans des environnements autre que Node.js](non-node.md)
+- [Utilisation dans des environnements autres que Node.js](non-node.md)
 - [Référence de l'API](api.md)
   - [createRenderer](api.md#createrendereroptions)
   - [createBundleRenderer](api.md#createbundlerendererbundle-options)

--- a/en/api.md
+++ b/en/api.md
@@ -42,7 +42,7 @@ Voyez l'[Introduction au moteur de dépaquetage](./bundle-renderer.md) et la [Co
 
 - #### `renderer.renderToStream(vm[, context]): stream.Readable`
 
-  Render a Vue instance to a [Node.js readble stream](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). The context object is optional. See [Streaming](./streaming.md) for more details.
+  Fait le rendu d'une instance de Vue sous forme de [flux Node.js](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). L'objet de contexte est optionnel. Voir l'[Envoi par flux](./streaming.md) pour plus de détails.
 
 ## `Class: BundleRenderer`
 

--- a/en/api.md
+++ b/en/api.md
@@ -40,10 +40,6 @@ Voyez l'[Introduction au moteur de dépaquetage](./bundle-renderer.md) et la [Co
 
   Fait le rendu d'une instance de Vue sous forme de [flux Node.js](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). L'objet de contexte est optionnel. Voir l'[Envoi par flux](./streaming.md) pour plus de détails.
 
-- #### `renderer.renderToStream(vm[, context]): stream.Readable`
-
-  Fait le rendu d'une instance de Vue sous forme de [flux Node.js](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). L'objet de contexte est optionnel. Voir l'[Envoi par flux](./streaming.md) pour plus de détails.
-
 ## `Class: BundleRenderer`
 
 - #### `bundleRenderer.renderToString([context, callback]): ?Promise<string>`

--- a/en/api.md
+++ b/en/api.md
@@ -34,15 +34,15 @@ Voyez l'[Introduction au moteur de dépaquetage](./bundle-renderer.md) et la [Co
 
   Fait le rendu d'une instance de Vue sous forme de chaine de caractères. L'objet de contexte est optionnel. La fonction de rappel est une fonction de rappel typique de Node.js avec en premier argument l'erreur potentielle et en second argument la chaine de caractères du rendu.
 
-  In 2.5.0+, the callback is also optional. When no callback is passed, the method returns a Promise which resolves to the rendered HTML.
+  Dans la 2.5.0+, la fonction de rappel est également optionnelle. Quand aucune fonction de rappel n'est fournie, la méthode retourne une promesse résolue avec le HTML rendu.
 
-<<<<<<< HEAD
-  Fait le rendu d'une instance de Vue sous forme de flux. L'objet de contexte est optionnel. Voir l'[Envoi par flux](./streaming.md) pour plus de détails.
-=======
+- #### `renderer.renderToStream(vm[, context]): stream.Readable`
+
+  Fait le rendu d'une instance de Vue sous forme de [flux Node.js](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). L'objet de contexte est optionnel. Voir l'[Envoi par flux](./streaming.md) pour plus de détails.
+
 - #### `renderer.renderToStream(vm[, context]): stream.Readable`
 
   Render a Vue instance to a [Node.js readble stream](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). The context object is optional. See [Streaming](./streaming.md) for more details.
->>>>>>> upstream/master
 
 ## `Class: BundleRenderer`
 
@@ -50,15 +50,11 @@ Voyez l'[Introduction au moteur de dépaquetage](./bundle-renderer.md) et la [Co
 
   Fait le rendu d'un paquetage sous forme de chaine de caractères. L'objet de contexte est optionnel. La fonction de rappel est une fonction de rappel typique de Node.js avec en premier argument l'erreur potentielle et en second argument la chaine de caractères du rendu.
 
-  In 2.5.0+, the callback is also optional. When no callback is passed, the method returns a Promise which resolves to the rendered HTML.
+  Dans la 2.5.0+, la fonction de rappel est également optionnelle. Quand aucune fonction de rappel n'est fournie, la méthode retourne une promesse résolue avec le HTML rendu.
 
 - #### `bundleRenderer.renderToStream([context]): stream.Readable`
 
-<<<<<<< HEAD
-  Fait le rendu d'un paquetage sous forme de flux. L'objet de contexte est optionnel. Voir l'[Envoi par flux](./streaming.md) pour plus de détails.
-=======
-  Render the bundle to a [Node.js readble stream](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). The context object is optional. See [Streaming](./streaming.md) for more details.
->>>>>>> upstream/master
+  Fait le rendu d'un paquetage sous forme de [flux Node.js](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). L'objet de contexte est optionnel. Voir l'[Envoi par flux](./streaming.md) pour plus de détails.
 
 ## Options de `Renderer`
 
@@ -79,13 +75,9 @@ Voyez l'[Introduction au moteur de dépaquetage](./bundle-renderer.md) et la [Co
 
   - `context.state`: (Object) L'état initial du store Vuex devrait être injecté dans la page sous la variable `window.__INITIAL_STATE__`. Le JSON en ligne est automatiquement désinfecté avec [serialize-javascript](https://github.com/yahoo/serialize-javascript) pour éviter les injections XSS.
 
-<<<<<<< HEAD
-  En plus, quand `clientManifest` est fourni, le modèle de page injecte automatiquement les éléments suivants :
-=======
-    In 2.5.0+, the embed script also self-removes in production mode.
+    Dans la 2.5.0+, les scripts injectés sont automatiquement retiré en mode production.
 
-  In addition, when `clientManifest` is also provided, the template automatically injects the following:
->>>>>>> upstream/master
+  En plus, quand `clientManifest` est fourni, le modèle de page injecte automatiquement les éléments suivants :
 
   - JavaScript client et fichiers CSS nécessaires pour le rendu (avec les fragments asynchrones automatiquement déduits),
   - utilisation optimale des indices de ressources `<link rel="preload/prefetch">` pour le rendu de la page.
@@ -147,9 +139,9 @@ Voyez l'[Introduction au moteur de dépaquetage](./bundle-renderer.md) et la [Co
 
   - 2.5.0+
 
-  A function to control what files should have `<link rel="prefetch">` resource hints generated.
+  Une fonction pour contrôler quels fichiers devraient avoir l'indice de ressource `<link rel="prefetch">` généré.
 
-  By default, all assets in async chunks will be prefetched since this is a low-priority directive; however you can customize what to prefetch in order to better control bandwidth usage. This option expects the same function signature as `shouldPreload`.
+  Par défaut, toutes les ressources sont des morceaux asynchrones qui vont être prérécupérés du fait que se sont des directives de basse priorité. Cependant vous pouvez personnaliser c qui est prérécupérés afin d'avoir un meilleur contrôle sur l'utilisation de la bande passante. Cette option utilise une déclaration de fonction identique à celle de `shouldPreload`.
 
 - #### `runInNewContext`
 

--- a/en/api.md
+++ b/en/api.md
@@ -141,7 +141,7 @@ Voyez l'[Introduction au moteur de dépaquetage](./bundle-renderer.md) et la [Co
 
   Une fonction pour contrôler quels fichiers devraient avoir l'indice de ressource `<link rel="prefetch">` généré.
 
-  Par défaut, toutes les ressources sont des morceaux asynchrones qui vont être prérécupérés du fait que se sont des directives de basse priorité. Cependant vous pouvez personnaliser c qui est prérécupérés afin d'avoir un meilleur contrôle sur l'utilisation de la bande passante. Cette option utilise une déclaration de fonction identique à celle de `shouldPreload`.
+  Par défaut, toutes les ressources sont des morceaux asynchrones qui vont être préchargés du fait que se sont des directives de basse priorité. Cependant vous pouvez personnaliser ce qui est préchargé afin d'avoir un meilleur contrôle sur l'utilisation de la bande passante. Cette option utilise une déclaration de fonction identique à celle de `shouldPreload`.
 
 - #### `runInNewContext`
 

--- a/en/non-node.md
+++ b/en/non-node.md
@@ -1,6 +1,6 @@
 # Utilisation dans des environnements autres que Node.js
 
-Le build par défaut de `vue-server-renderer` est créer pour fonctionner dans un environnement Node.js, ce qui le rend inutilisable pour des environnements comme [PHP V8Js](https://github.com/phpv8/v8js) ou [Oracle Nashorn](https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/). Dans la 2.5+, nous avons ajouté un build dans `vue-server-renderer/basic.js` qui est très largement agnostique en matière d'environnement, le rendant utilisable dans les environnements mentionnés précédemment.
+Le build par défaut de `vue-server-renderer` est créé pour fonctionner dans un environnement Node.js, ce qui le rend inutilisable pour des environnements comme [PHP V8Js](https://github.com/phpv8/v8js) ou [Oracle Nashorn](https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/). Dans la 2.5+, nous avons ajouté un build dans `vue-server-renderer/basic.js` qui est très largement agnostique en matière d'environnement, le rendant utilisable dans les environnements mentionnés précédemment.
 
 Pour les deux environnements, il est nécessaire de d'abord préparer l'environnement en simulant les objets `global` et `process` avec `process.env.VUE_ENV` mis à `"server"` et `process.env.NODE_ENV` mis à `"development"` ou `"production"`.
 

--- a/en/non-node.md
+++ b/en/non-node.md
@@ -1,12 +1,12 @@
-# Usage in non-Node.js Environments
+# Utilisation dans des environnements autres que Node.js
 
-The default build of `vue-server-renderer` assumes a Node.js environment, which makes it unusable in alternative JavaScript environments such as [php-v8js](https://github.com/phpv8/v8js) or [Nashorn](https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/). In 2.5 we have shipped a build in `vue-server-renderer/basic.js` that is largely environment-agnostic, which makes it usable in the environments mentioned above.
+Le build par défaut de `vue-server-renderer` est créer pour fonctionner dans un environnement Node.js, ce qui le rend inutilisable pour des environnements comme [PHP V8Js](https://github.com/phpv8/v8js) ou [Oracle Nashorn](https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/). Dans la 2.5+, nous avons ajouté un build dans `vue-server-renderer/basic.js` qui est très largement agnostique en matière d'environnement, le rendant utilisable dans les environnements mentionnés précédemment.
 
-For both environments, it is necessary to first prepare the environment by mocking the `global` and `process` objects, with `process.env.VUE_ENV` set to `"server"`, and `process.env.NODE_ENV` set to `"development"` or `"production"`.
+Pour les deux environnements, il est nécessaire de d'abord préparer l'environnement en simulant les objets `global` et `process` avec `process.env.VUE_ENV` mis à `"server"` et `process.env.NODE_ENV` mis à `"development"` ou `"production"`.
 
-In Nashorn, it may also be necessary to provide a polyfill for `Promise` or `setTimeout` using Java's native timers.
+Dans Nashorn, il serait également nécessaire de fournir un polyfill pour les `Promise` ou `setTimeout` en utilisant les compteurs natifs Java.
 
-Example usage in php-v8js:
+Exemple d'utilisation avec V8Js :
 
 ``` php
 <?php
@@ -30,11 +30,11 @@ $v8->executeString($app_source);
 var vm = new Vue({
   template: `<div>{{ msg }}</div>`,
   data: {
-    msg: 'hello'
+    msg: 'bonjour'
   }
 })
 
-// exposed by vue-server-renderer/basic.js
+// exposé par `vue-server-renderer/basic.js`
 renderVueComponentToString(vm, (err, res) => {
   print(res)
 })


### PR DESCRIPTION
Une nouvelle traduction à revoir !

Il y a quelque ajustement à revoir sur ce commit si vous voulez y jeter un œil : 
— https://github.com/vuejs-fr/vue-ssr-docs/commit/bb8fb6f79e4959d6636c7708f09d7d11f20d6686